### PR TITLE
Trick to avoid checking of Option<Cache>

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -6,7 +6,27 @@ use async_trait::async_trait;
 use std::marker::{Send, Sync};
 
 #[async_trait]
-pub trait Cache<T>: Clone + Send + Sync {
+pub trait Cache<T>: Send + Sync {
     async fn set<S: ToString + Send + Sync>(&self, id: S, obj: T) -> Result<()>;
     async fn get<S: ToString + Send + Sync>(&self, id: S) -> Result<Option<T>>;
+}
+
+#[async_trait]
+impl<T, C> Cache<T> for Option<C>
+where
+    C: Cache<T>,
+    T: Send + Sync + 'static,
+{
+    async fn set<S: ToString + Send + Sync>(&self, id: S, obj: T) -> Result<()> {
+        match self {
+            Some(cache) => cache.set(id, obj).await,
+            None => Ok(()),
+        }
+    }
+    async fn get<S: ToString + Send + Sync>(&self, id: S) -> Result<Option<T>> {
+        match self {
+            Some(cache) => cache.get(id).await,
+            None => Ok(None),
+        }
+    }
 }


### PR DESCRIPTION
This implements the Cache trait for any Option<Cache> this
means that we can disable cache by just setting Cache to None.

This way the code that uses the cache does not have to check if cache
set or not