### PR TITLE
Proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ uuid = {version = "1.1.0", features = ["v4"]}
 md5 = "0.7.0"
 clap = {version = "3.1", features = ["derive"]}
 openssl = { version = "=0.10.40", features = ["vendored"] }
+base64 = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,4 @@ http = "0.2.7"
 uuid = {version = "1.1.0", features = ["v4"]}
 md5 = "0.7.0"
 clap = {version = "3.1", features = ["derive"]}
-openssl = { version = "=0.10.40", features = ["vendored"] }
 base64 = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ http = "0.2.7"
 uuid = {version = "1.1.0", features = ["v4"]}
 md5 = "0.7.0"
 clap = {version = "3.1", features = ["derive"]}
+openssl = { version = "=0.10.40", features = ["vendored"] }

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -189,7 +189,7 @@ The point is the 3rd party app, once it receives a `payload` message and once it
 This mean that this envelope message will end up on the `msgbus.system.proxy` queue (if all validation is fine). A special routine handler on this queue will does the following:
 
 - it will extract the `payload` message from the `data` field of the `envelope`
-- it will does payload validation (against the sender twin id), and timestamps validation, etc...
+- it will do payload validation (against the sender twin id), and timestamps validation, etc...
 - the message `$ret` is set to `msgbus.system.proxied`
 - the envelope message is parked in redis (using a special) `proxied.$id` key. TTL is applied
 - the message is sent to `msgbus.$cmd`

--- a/src/http_api/entry.rs
+++ b/src/http_api/entry.rs
@@ -74,7 +74,7 @@ enum HandlerError {
     #[error("invalid source twin {0}: {1}")]
     InvalidSource(u32, anyhow::Error),
 
-    #[error("internal server error")]
+    #[error("internal server error: {0}")]
     InternalError(#[from] anyhow::Error),
 }
 
@@ -148,7 +148,7 @@ async fn rmb_remote_handler<S: Storage, I: Identity, D: TwinDB>(
     let message = message(request, &data).await?;
 
     data.storage
-        .run(&message)
+        .run(message)
         .await
         .map_err(HandlerError::InternalError)
 }

--- a/src/http_api/entry.rs
+++ b/src/http_api/entry.rs
@@ -259,7 +259,7 @@ mod tests {
         msg.source = 1;
         msg.destination = vec![2];
         msg.data = String::from("dsads");
-        msg.now = SystemTime::now()
+        msg.timestamp = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();
@@ -296,7 +296,7 @@ mod tests {
         msg.source = 3;
         msg.destination = vec![2];
         msg.data = String::from("message data");
-        msg.now = SystemTime::now()
+        msg.timestamp = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();

--- a/src/http_api/entry.rs
+++ b/src/http_api/entry.rs
@@ -62,19 +62,19 @@ where
 }
 #[derive(Error, Debug)]
 enum HandlerError {
-    #[error("bad request: {0}")]
+    #[error("bad request: {0:#}")]
     BadRequest(anyhow::Error),
 
-    #[error("un authorized: {0}")]
+    #[error("un authorized: {0:#}")]
     UnAuthorized(anyhow::Error),
 
     #[error("invalid destination twin {0}")]
     InvalidDestination(u32),
 
-    #[error("invalid source twin {0}: {1}")]
+    #[error("invalid source twin {0}: {1:#}")]
     InvalidSource(u32, anyhow::Error),
 
-    #[error("internal server error: {0}")]
+    #[error("internal server error: {0:#}")]
     InternalError(#[from] anyhow::Error),
 }
 

--- a/src/http_api/mock.rs
+++ b/src/http_api/mock.rs
@@ -4,7 +4,7 @@ use crate::{
     identity::{self, Ed25519Signer, Identity},
     storage::Storage,
     twin::{Twin, TwinDB},
-    types::{Message, QueuedMessage},
+    types::{Message, TransitMessage},
 };
 use anyhow::Result;
 use sp_core::crypto::{AccountId32, Ss58Codec};
@@ -30,8 +30,8 @@ impl Storage for StorageMock {
     async fn local(&self) -> Result<Message> {
         Ok(Message::default())
     }
-    async fn queued(&self) -> Result<QueuedMessage> {
-        Ok(QueuedMessage::Forward(Message::default()))
+    async fn queued(&self) -> Result<TransitMessage> {
+        Ok(TransitMessage::Request(Message::default()))
     }
 }
 #[derive(Clone)]

--- a/src/http_api/mock.rs
+++ b/src/http_api/mock.rs
@@ -17,7 +17,7 @@ impl Storage for StorageMock {
     async fn get(&self, _id: &str) -> Result<Option<Message>> {
         Ok(Some(Message::default()))
     }
-    async fn run(&self, _msg: &Message) -> Result<()> {
+    async fn run(&self, _msg: Message) -> Result<()> {
         Ok(())
     }
     async fn forward(&self, _msg: &Message) -> Result<()> {

--- a/src/http_workers/work_runner.rs
+++ b/src/http_workers/work_runner.rs
@@ -31,7 +31,7 @@ enum SendError {
     #[error("receive error reply from remote rmb: `{0}`")]
     Terminal(String),
 
-    #[error("failed to deliver message to remote rmb: {0}")]
+    #[error("failed to deliver message to remote rmb: {0:#}")]
     Error(#[from] anyhow::Error),
 }
 

--- a/src/http_workers/work_runner.rs
+++ b/src/http_workers/work_runner.rs
@@ -213,9 +213,6 @@ where
                 }
             };
 
-            // set time
-            msg.set_now();
-
             // signing the message
             msg.sign(&self.identity);
 

--- a/src/http_workers/work_runner.rs
+++ b/src/http_workers/work_runner.rs
@@ -157,7 +157,7 @@ where
             .await
             .context("can not send a reply message")
         {
-            log::error!("{:?}", err);
+            log::error!("failed to deliver failure response: {}", err);
         }
     }
 }
@@ -192,7 +192,7 @@ where
             // getting twin object
             let twin = match self.get_twin(*id, retry).await {
                 Some(twin) => twin,
-                None if queue == Queue::Forward => {
+                None if queue == Queue::Request => {
                     self.handle_delivery_err(
                         *id,
                         msg,

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,7 +216,7 @@ async fn processor<S: Storage>(id: u32, storage: S) {
         // set the message id.
         msg.id = uuid::Uuid::new_v4().to_string();
         msg.retry = between(msg.retry, MIN_RETRIES, MAX_RETRIES);
-        msg.expiration = between(msg.expiration, MIN_DURATION, MAX_DURATION);
+        msg.stamp();
 
         // push message to forward.
         while let Err(err) = storage.forward(&msg).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,9 +224,8 @@ async fn processor<S: Storage>(id: u32, storage: S) {
         msg.stamp();
 
         // push message to forward.
-        while let Err(err) = storage.forward(&msg).await {
+        if let Err(err) = storage.forward(&msg).await {
             log::error!("failed to push message for forwarding: {}", err);
-            sleep(wait).await;
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod cache;
 mod http_api;
 mod http_workers;
 mod identity;
+mod proxy;
 mod redis;
 mod storage;
 mod twin;

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -35,7 +35,6 @@ where
         let mut payload = Message::from_json(&payload).context("invalid payload message")?;
 
         payload.id = envelope.id.clone();
-
         if !payload.destination.iter().any(|x| *x == self.id) {
             // this message is not intended to this destination
             // and this is a violation that is not accepted

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -34,9 +34,7 @@ where
         let payload = base64::decode(&envelope.data).context("failed to decode payload")?;
         let mut payload = Message::from_json(&payload).context("invalid payload message")?;
 
-        if envelope.id != payload.id {
-            bail!("payload message id must be the same as the envelope id");
-        }
+        payload.id = envelope.id.clone();
 
         if !payload.destination.iter().any(|x| *x == self.id) {
             // this message is not intended to this destination
@@ -62,7 +60,7 @@ where
     }
 
     async fn handle_err(&self, mut msg: Message, err: anyhow::Error) {
-        msg.error = Some(err.to_string());
+        msg.error = Some(format!("{:#}", err));
         msg.data = String::default();
 
         if let Err(err) = self.storage.response(&msg).await {

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,0 +1,102 @@
+use anyhow::{Context, Result};
+/// proxy is a special worker that accept handle messages with command system.proxy.
+/// those messages than are specially treated according to specs
+use std::{sync::Arc, time::Duration};
+
+use crate::{
+    storage::ProxyStorage,
+    twin::TwinDB,
+    types::{Message, TransitMessage},
+    workers::{Work, WorkerPool},
+};
+
+struct Worker<S, T> {
+    storage: S,
+    db: T,
+}
+
+impl<S, T> Worker<S, T> {
+    pub fn new(storage: S, db: T) -> Self {
+        Worker { storage, db }
+    }
+}
+
+impl<S, T> Worker<S, T>
+where
+    S: ProxyStorage,
+    T: TwinDB,
+{
+    async fn request_handler(&self, msg: Message) -> Result<()> {
+        // if we are here this is a msg with command system.proxy.
+        // all envelope validation is complete. But we need now to extract
+        // the payload of the message. and then validate this as a separate message
+        let payload = base64::decode(&msg.data).context("failed to decode payload")?;
+        let mut message = Message::from_json(&payload).context("invalid payload message")?;
+
+        Ok(())
+    }
+    async fn request(&self, msg: Message) {
+        if let Err(err) = self.request_handler(msg).await {
+            todo!("handle error by sending a response to caller");
+        }
+    }
+
+    async fn reply(&self, msg: Message) {}
+}
+#[async_trait::async_trait]
+impl<S, T> Work for Worker<S, T>
+where
+    S: ProxyStorage,
+    T: TwinDB,
+{
+    type Job = TransitMessage;
+
+    async fn run(&self, job: Self::Job) {
+        match job {
+            TransitMessage::Request(msg) => self.request(msg).await,
+            TransitMessage::Reply(msg) => self.reply(msg).await,
+        }
+    }
+}
+
+pub struct ProxyWorker<S, T>
+where
+    S: ProxyStorage,
+    T: TwinDB,
+{
+    storage: S,
+    pool: WorkerPool<Arc<Worker<S, T>>>,
+}
+
+impl<S, T> ProxyWorker<S, T>
+where
+    S: ProxyStorage,
+    T: TwinDB,
+{
+    // this must be async because of the workpool new function must be async
+    pub fn new(size: usize, storage: S, twin_db: T) -> Self {
+        // it's cheaper to create one http client and then clone it to the workers
+        // according to docs this will make it share the same connection pool.
+        let worker = Worker::new(storage.clone(), twin_db);
+        let pool = WorkerPool::new(Arc::new(worker), size);
+        Self { storage, pool }
+    }
+
+    pub async fn run(mut self) {
+        loop {
+            let handler = self.pool.get().await;
+
+            let job = match self.storage.queued().await {
+                Ok(job) => job,
+                Err(err) => {
+                    log::debug!("error while process the storage because of '{}'", err);
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+            };
+            if let Err(err) = handler.send(job) {
+                log::error!("failed to send job to worker: {}", err);
+            }
+        }
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -35,7 +35,7 @@ pub trait Storage: Clone + Send + Sync + 'static {
     // message will be auto-dropped when it times out.
     async fn forward(&self, msg: &Message) -> Result<()>;
 
-    // pushes message to `msg.$ret` queue.
+    /// pushes message to `msg.$ret` queue.
     async fn reply(&self, msg: &Message) -> Result<()>;
 
     // gets a message from local queue waits
@@ -54,7 +54,11 @@ pub trait ProxyStorage: Storage {
     /// store message in park with proper key
     async fn park(&self, msg: &Message) -> Result<()>;
 
+    async fn unpark(&self, id: &str) -> Result<Option<Message>>;
     /// proxy returns the next available message from
     /// the proxy channels (forward or return)
     async fn proxy(&self) -> Result<TransitMessage>;
+
+    ///
+    async fn respond(&self, msg: &Message) -> Result<()>;
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -27,7 +27,7 @@ pub trait Storage: Clone + Send + Sync + 'static {
     // SUGGESTED FIX: instead of setting TTL on the $cmd queue we can limit the length
     // of the queue. So for example, we allow maximum of 500 message to be on this queue
     // after that we need to trim the queue to specific length after push (so drop older messages)
-    async fn run(&self, msg: &Message) -> Result<()>;
+    async fn run(&self, msg: Message) -> Result<()>;
 
     // forward stores the message in backlog.$id, and for each twin id in the message
     // destination, a new tuple of (id, dst) is pushed to the forward queue.
@@ -51,14 +51,14 @@ pub trait Storage: Clone + Send + Sync + 'static {
 /// for proxy submodule.
 #[async_trait]
 pub trait ProxyStorage: Storage {
-    /// store message in park with proper key
-    async fn park(&self, msg: &Message) -> Result<()>;
+    /// run proxied runs the command but with an overriden reply queue
+    /// that is specific for the proxy module.
+    async fn run_proxied(&self, msg: Message) -> Result<()>;
 
-    async fn unpark(&self, id: &str) -> Result<Option<Message>>;
     /// proxy returns the next available message from
-    /// the proxy channels (forward or return)
-    async fn proxy(&self) -> Result<TransitMessage>;
+    /// the proxy channels (request or reply)
+    async fn proxied(&self) -> Result<TransitMessage>;
 
     /// send msg back to the reply queue of the storage.
-    async fn respond(&self, msg: &Message) -> Result<()>;
+    async fn response(&self, msg: &Message) -> Result<()>;
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,7 +1,8 @@
 mod redis;
+
 pub use redis::*;
 
-use crate::types::{Message, QueuedMessage};
+use crate::types::{Message, TransitMessage};
 use anyhow::Result;
 use async_trait::async_trait;
 
@@ -43,5 +44,17 @@ pub trait Storage: Clone + Send + Sync + 'static {
 
     // process will wait on both msgbus.system.forward AND msgbus.system.reply
     // and return the first message available with the correct Queue type
-    async fn queued(&self) -> Result<QueuedMessage>;
+    async fn queued(&self) -> Result<TransitMessage>;
+}
+
+/// extends the storage trait with functionality
+/// for proxy submodule.
+#[async_trait]
+pub trait ProxyStorage: Storage {
+    /// store message in park with proper key
+    async fn park(&self, msg: &Message) -> Result<()>;
+
+    /// proxy returns the next available message from
+    /// the proxy channels (forward or return)
+    async fn proxy(&self) -> Result<TransitMessage>;
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -59,6 +59,6 @@ pub trait ProxyStorage: Storage {
     /// the proxy channels (forward or return)
     async fn proxy(&self) -> Result<TransitMessage>;
 
-    ///
+    /// send msg back to the reply queue of the storage.
     async fn respond(&self, msg: &Message) -> Result<()>;
 }

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -345,18 +345,22 @@ mod tests {
         let mut conn = storage.get_connection().await?;
         let queue = storage.prefixed(Queue::Local);
 
+        use std::time::SystemTime;
         let msg = Message {
             version: 1,
             id: String::from(id),
             command: String::from("test.get"),
-            expiration: 0,
+            expiration: 300,
             data: String::from(""),
             source: 1,
             destination: vec![4],
             reply: String::from("de31075e-9af4-4933-b107-c36887d0c0f0"),
             retry: 2,
             schema: String::from(""),
-            timestamp: 1653454930,
+            timestamp: SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
             error: None,
             signature: None,
         };

--- a/src/twin/substrate.rs
+++ b/src/twin/substrate.rs
@@ -38,6 +38,7 @@ where
         }
 
         let client = self.client.clone();
+        log::debug!("getting twin {} from substrate", twin_id);
         let twin: Twin = spawn_blocking(move || client.get_twin(twin_id)).await??;
         self.cache.set(twin.id, twin.clone()).await?;
         Ok(Some(twin))

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,8 +7,8 @@ use std::io::Write;
 use std::time::{Duration, SystemTime};
 
 #[derive(Clone)]
-pub enum QueuedMessage {
-    Forward(Message),
+pub enum TransitMessage {
+    Request(Message),
     Reply(Message),
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -144,10 +144,7 @@ impl Message {
         // to compute the ttl we need to do the following
         // - ttl = expiration - (now - msg.timestamp)
         match now.checked_sub(self.timestamp) {
-            Some(d) => match self.expiration.checked_sub(d) {
-                Some(sec) => Some(Duration::from_secs(sec)),
-                None => None,
-            },
+            Some(d) => self.expiration.checked_sub(d).map(Duration::from_secs),
             None => None,
         }
     }

--- a/substrate_client/Cargo.toml
+++ b/substrate_client/Cargo.toml
@@ -14,6 +14,7 @@ sp-keyring = "3.0.0"
 # frame-support = "3.0.0"
 # frame-system = "3"
 parity-scale-codec = "3.1.2"
+openssl = { version = "=0.10.40", features = ["vendored"] }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/substrate_client/Cargo.toml
+++ b/substrate_client/Cargo.toml
@@ -14,7 +14,6 @@ sp-keyring = "3.0.0"
 # frame-support = "3.0.0"
 # frame-system = "3"
 parity-scale-codec = "3.1.2"
-openssl = { version = "=0.10.40", features = ["vendored"] }
 
 [dev-dependencies]
 env_logger = "0.9.0"


### PR DESCRIPTION
- This implements a proxy workers 
- When a message is sent with special command `system.proxy.request` the message is handled by the worker
- The worker extracts the payload of the message which is the 'proxied' message. 
- The proxied message is verified normally (timestamp, signatures, etc...)
  -  Not a pyaload request can't live longer that it's envelope so only TTL for the envelope applies.
- The payload message is assigned a special (ret) queue which is also handled by the proxy workers.
- Once a proxy worker gets a reply, it brings back it's envelope 
   -  message is dropped if envelope has expired.
- reply is encapsulated in another response message
- sent back to the caller  