### PR TITLE
support loading keys from seed and add a new flag for it

### DIFF
--- a/src/identity/ed25519.rs
+++ b/src/identity/ed25519.rs
@@ -71,3 +71,27 @@ fn verify<P: AsRef<[u8]>, M: AsRef<[u8]>>(pk: &Public, sig: P, message: M) -> bo
     assert_eq!(sig[0], PREFIX, "invalid signature type");
     EdPair::verify_weak(&sig[1..], message, pk)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WORDS: &str = "neck stage box cup core magic produce exercise happy rely vocal then";
+    const SEED: &str = "0xaa4e323bade8609a595108b585c4135855430c411ccf7923f81438cd8a188fce";
+
+    #[test]
+    fn test_load_from_mnemonics() {
+        Ed25519Signer::try_from(WORDS).expect("key must be loaded");
+
+        let err = Ed25519Signer::try_from("invalid words");
+        assert_eq!(err.is_err(), true);
+    }
+
+    #[test]
+    fn test_load_from_seed() {
+        Ed25519Signer::try_from(SEED).expect("key must be loaded");
+
+        let err = Ed25519Signer::try_from("0xinvalidseed");
+        assert_eq!(err.is_err(), true);
+    }
+}

--- a/src/identity/ed25519.rs
+++ b/src/identity/ed25519.rs
@@ -89,7 +89,14 @@ mod tests {
 
     #[test]
     fn test_load_from_seed() {
-        Ed25519Signer::try_from(SEED).expect("key must be loaded");
+        let s = Ed25519Signer::try_from(SEED).expect("key must be loaded");
+
+        let result =
+            hex::decode("aa4e323bade8609a595108b585c4135855430c411ccf7923f81438cd8a188fce")
+                .expect("must be decoded");
+
+        let bytes: [u8; 32] = result.as_slice().try_into().expect("key of size 32");
+        assert_eq!(s.pair.seed(), &bytes);
 
         let err = Ed25519Signer::try_from("0xinvalidseed");
         assert_eq!(err.is_err(), true);

--- a/src/identity/ed25519.rs
+++ b/src/identity/ed25519.rs
@@ -91,9 +91,7 @@ mod tests {
     fn test_load_from_seed() {
         let s = Ed25519Signer::try_from(SEED).expect("key must be loaded");
 
-        let result =
-            hex::decode("aa4e323bade8609a595108b585c4135855430c411ccf7923f81438cd8a188fce")
-                .expect("must be decoded");
+        let result = hex::decode(&SEED[2..SEED.len()]).expect("must be decoded");
 
         let bytes: [u8; 32] = result.as_slice().try_into().expect("key of size 32");
         assert_eq!(s.pair.seed(), &bytes);

--- a/src/identity/ed25519.rs
+++ b/src/identity/ed25519.rs
@@ -33,8 +33,6 @@ impl From<&AccountId32> for Ed25519Identity {
 #[derive(Clone)]
 pub struct Ed25519Signer {
     pair: EdPair,
-    #[allow(unused)]
-    seed: [u8; 32],
 }
 
 impl Signer for Ed25519Signer {
@@ -59,12 +57,11 @@ impl Identity for Ed25519Signer {
 
 impl TryFrom<&str> for Ed25519Signer {
     type Error = anyhow::Error;
-    fn try_from(phrase: &str) -> std::result::Result<Self, Self::Error> {
-        // let (pair, seed) = sp_keyring::ed25519::Pair::from_phrase(phrase, None)?;
-        let (pair, seed) = sp_core::ed25519::Pair::from_phrase(phrase, None)
+    fn try_from(s: &str) -> std::result::Result<Self, Self::Error> {
+        let (pair, _) = sp_core::ed25519::Pair::from_string_with_seed(s, None)
             .map_err(|err| anyhow!("{:?}", err))?;
 
-        Ok(Self { pair, seed })
+        Ok(Self { pair })
     }
 }
 

--- a/src/identity/ed25519.rs
+++ b/src/identity/ed25519.rs
@@ -58,8 +58,8 @@ impl Identity for Ed25519Signer {
 impl TryFrom<&str> for Ed25519Signer {
     type Error = anyhow::Error;
     fn try_from(s: &str) -> std::result::Result<Self, Self::Error> {
-        let (pair, _) = sp_core::ed25519::Pair::from_string_with_seed(s, None)
-            .map_err(|err| anyhow!("{:?}", err))?;
+        let pair =
+            sp_core::ed25519::Pair::from_string(s, None).map_err(|err| anyhow!("{:?}", err))?;
 
         Ok(Self { pair })
     }

--- a/src/identity/sr25519.rs
+++ b/src/identity/sr25519.rs
@@ -59,7 +59,6 @@ impl TryFrom<&str> for Sr25519Signer {
     type Error = anyhow::Error;
 
     fn try_from(s: &str) -> std::result::Result<Self, Self::Error> {
-        // let (pair, seed) = sp_keyring::ed25519::Pair::from_phrase(phrase, None)?;
         let (pair, _) = sp_core::sr25519::Pair::from_string_with_seed(s, None)
             .map_err(|err| anyhow!("{:?}", err))?;
 
@@ -72,4 +71,29 @@ fn verify<P: AsRef<[u8]>, M: AsRef<[u8]>>(pk: &Public, sig: P, message: M) -> bo
     assert_eq!(sig.len(), SIGNATURE_LENGTH, "invalid signature length");
     assert_eq!(sig[0], PREFIX, "invalid signature type");
     SrPair::verify_weak(&sig[1..], message, pk)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WORDS: &str =
+        "volume behind cable present pull exchange wish loyal avocado snap film increase";
+    const SEED: &str = "0xb37231837527c7173dc212bb23a7fe795d5dae540e7c21366a5fb9f4cc398a36";
+
+    #[test]
+    fn test_load_from_mnemonics() {
+        Sr25519Signer::try_from(WORDS).expect("key must be loaded");
+
+        let err = Sr25519Signer::try_from("invalid words");
+        assert_eq!(err.is_err(), true);
+    }
+
+    #[test]
+    fn test_load_from_seed() {
+        Sr25519Signer::try_from(SEED).expect("key must be loaded");
+
+        let err = Sr25519Signer::try_from("0xinvalidseed");
+        assert_eq!(err.is_err(), true);
+    }
 }

--- a/src/identity/sr25519.rs
+++ b/src/identity/sr25519.rs
@@ -33,8 +33,6 @@ impl From<&AccountId32> for Sr25519Identity {
 #[derive(Clone)]
 pub struct Sr25519Signer {
     pair: SrPair,
-    #[allow(unused)]
-    seed: [u8; 32],
 }
 
 impl Signer for Sr25519Signer {
@@ -60,12 +58,12 @@ impl Identity for Sr25519Signer {
 impl TryFrom<&str> for Sr25519Signer {
     type Error = anyhow::Error;
 
-    fn try_from(phrase: &str) -> std::result::Result<Self, Self::Error> {
-        // let (pair, seed) = sp_keyring::sr25519::Pair::from_phrase(phrase, None)?;
-        let (pair, seed) = sp_core::sr25519::Pair::from_phrase(phrase, None)
-            .map_err(|err| anyhow::anyhow!("{:?}", err))?;
+    fn try_from(s: &str) -> std::result::Result<Self, Self::Error> {
+        // let (pair, seed) = sp_keyring::ed25519::Pair::from_phrase(phrase, None)?;
+        let (pair, _) = sp_core::sr25519::Pair::from_string_with_seed(s, None)
+            .map_err(|err| anyhow!("{:?}", err))?;
 
-        Ok(Self { pair, seed })
+        Ok(Self { pair })
     }
 }
 

--- a/src/identity/sr25519.rs
+++ b/src/identity/sr25519.rs
@@ -59,8 +59,8 @@ impl TryFrom<&str> for Sr25519Signer {
     type Error = anyhow::Error;
 
     fn try_from(s: &str) -> std::result::Result<Self, Self::Error> {
-        let (pair, _) = sp_core::sr25519::Pair::from_string_with_seed(s, None)
-            .map_err(|err| anyhow!("{:?}", err))?;
+        let pair =
+            sp_core::sr25519::Pair::from_string(s, None).map_err(|err| anyhow!("{:?}", err))?;
 
         Ok(Self { pair })
     }


### PR DESCRIPTION
I removed the `seed` field, as it depends on the `pair` type, for example for `ed25519` it's available as `pair.seed()`. 

Related:

* #43