### PR TITLE
Message timestamp validation

### DIFF
--- a/src/http_api/entry.rs
+++ b/src/http_api/entry.rs
@@ -9,7 +9,11 @@ use hyper::{
 };
 use std::convert::Infallible;
 use std::net::SocketAddr;
+use std::time::Duration;
 use thiserror::Error;
+
+const MAX_AGE: Duration = Duration::from_secs(60);
+
 pub struct HttpApi<S, I, D>
 where
     S: Storage,
@@ -131,7 +135,16 @@ async fn message<S: Storage, I: Identity, D: TwinDB>(
         }
     };
 
-    message.valid().context("message validation failed")?;
+    message
+        .valid()
+        .context("message validation failed")
+        .map_err(HandlerError::BadRequest)?;
+
+    // we need to also check the message age to make sure
+    // it's not a 'reply'
+    if message.age() > MAX_AGE {
+        return Err(HandlerError::BadRequest(anyhow!("message is too old")));
+    }
 
     //verify the message
     message
@@ -161,9 +174,12 @@ pub async fn rmb_remote<S: Storage, I: Identity, D: TwinDB>(
         Ok(_) => Response::builder()
             .status(StatusCode::ACCEPTED)
             .body(Body::empty()),
-        Err(error) => Response::builder()
-            .status(error.code())
-            .body(Body::from(error.to_string())),
+        Err(error) => {
+            log::debug!("failed to handle request message: {}", error);
+            Response::builder()
+                .status(error.code())
+                .body(Body::from(error.to_string()))
+        }
     }
 }
 

--- a/src/http_workers/work_runner.rs
+++ b/src/http_workers/work_runner.rs
@@ -93,11 +93,7 @@ where
         }
     }
 
-    fn encrypt_dat(dat: String, _twin: &Twin) -> Result<String> {
-        Ok(dat)
-    }
-
-    async fn send_msg<U: AsRef<str>>(
+    async fn send_once<U: AsRef<str>>(
         &self,
         twin: &Twin,
         uri_path: U,
@@ -142,6 +138,48 @@ where
         } else {
             Ok(())
         }
+    }
+
+    async fn send(
+        &self,
+        id: u32,
+        retry: usize,
+        queue: &Queue,
+        msg: &mut Message,
+    ) -> Result<(), SendError> {
+        // getting twin object
+        let twin = match self.get_twin(id, retry).await {
+            Some(twin) => twin,
+            None => {
+                return Err(SendError::Terminal(format!(
+                    "twin with id {} not found",
+                    id
+                )))
+            }
+        };
+
+        // we always reset the tag to none before
+        // sending to remote
+        msg.tag = None;
+        msg.stamp();
+        msg.valid()
+            .context("message validation failed")
+            .map_err(SendError::Error)?;
+
+        // signing the message
+        msg.sign(&self.identity);
+
+        // posting the message to the remote twin
+        let mut result = Ok(());
+        for _ in 0..retry {
+            result = self.send_once(&twin, &queue, &msg).await;
+            if let Err(SendError::Error(_)) = &result {
+                continue;
+            }
+            break;
+        }
+
+        result
     }
 
     async fn handle_delivery_err(&self, twin: u32, mut msg: Message, err: SendError) {
@@ -194,50 +232,11 @@ where
             id,
             queue.as_ref()
         );
-        // getting twin object
-        let twin = match self.get_twin(id, retry).await {
-            Some(twin) => twin,
-            None if queue == Queue::Request => {
-                self.handle_delivery_err(
-                    id,
-                    msg,
-                    SendError::Terminal(format!("twin with id {} not found", id)),
-                )
-                .await;
 
-                return;
+        if let Err(err) = self.send(id, retry, &queue, &mut msg).await {
+            if queue == Queue::Request {
+                self.handle_delivery_err(id, msg, err).await;
             }
-            None => return,
-        };
-
-        // encrypt dat
-        msg.data = match Self::encrypt_dat(msg.data, &twin) {
-            Ok(dat) => dat,
-            Err(_err) => {
-                todo!()
-            }
-        };
-
-        // we always reset the tag to none before
-        // sending to remote
-        msg.tag = None;
-
-        // signing the message
-        msg.sign(&self.identity);
-
-        // posting the message to the remote twin
-        let mut result = Ok(());
-        for _ in 0..retry {
-            result = self.send_msg(&twin, &queue, &msg).await;
-            if let Err(SendError::Error(_)) = &result {
-                continue;
-            }
-            break;
-        }
-
-        if result.is_err() && queue == Queue::Request {
-            self.handle_delivery_err(twin.id, msg, result.err().unwrap())
-                .await;
         }
     }
 }

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -115,7 +115,9 @@ impl RedisStorage {
         };
 
         let key = self.prefixed(Queue::Backlog(&msg.id));
-        con.set_ex(&key, msg, ttl.as_secs() as usize).await?;
+        con.set_ex(&key, msg, ttl.as_secs() as usize)
+            .await
+            .with_context(|| format!("failed to set message ttl to '{}'", ttl.as_secs()))?;
 
         Ok(())
     }


### PR DESCRIPTION
We make sure that the message always has the correct
timestamp and expiration times.

message on the remote end need to be 'not expired' and at
the same time not very old (stampped less than 60 seconds ago)