### PR TITLE
update the call for ProxyWorker `new` method

### DIFF
--- a/src/e2e_tests.rs
+++ b/src/e2e_tests.rs
@@ -188,7 +188,7 @@ async fn start_rmb<
     let api_handler =
         tokio::spawn(HttpApi::new(id, address, storage.clone(), ident.clone(), db.clone())?.run());
 
-    let proxy_handler = tokio::spawn(ProxyWorker::new(id, 10, storage.clone(), db.clone()).run());
+    let proxy_handler = tokio::spawn(ProxyWorker::new(id, 10, storage.clone(), db.clone(), ident.clone()).run());
 
     let workers_handler = tokio::task::spawn(HttpWorker::new(1000, storage, db, ident).run());
 


### PR DESCRIPTION
ProxyWorker::new signature was changed recently (got extra parameter), this PR updates the code where it is called from in the integrations tests so it would work again.