### PR TITLE
Add port number to substrate on example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ in case of any build issues, things to try:
 Example of using sr25519 key on dev network
 
 ```sh
-rmb-rs --key-type sr25519 -s "wss://tfchain.dev.grid.tf" -m "<YOUR-MNEMONICS>"
+rmb-rs --key-type sr25519 -s "wss://tfchain.dev.grid.tf:443" -m "<YOUR-MNEMONICS>"
 ```
 
 **Debug logs** can be enabled by `-d` option.


### PR DESCRIPTION
Current line of code for example usage returns following error: 

cannot create substrate twin db object2: Rpc error: Networking or low-level protocol error: Invalid URL: No port number in URL (default port is not supported): Networking or low-level protocol error: Invalid URL: No port number in URL (default port is not supported): Invalid URL: No port number in URL (default port is not supported)

which is fixed if port number is included in substrate uri argument