### PR TITLE
a possible fix for substrate client reconnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,6 +1957,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
+ "jsonrpsee-core",
  "log",
  "md5",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "1.0.31"
 tokio = {version = "1", features = ["full"]}
 tokio-retry = "0.3"
 uuid = {version = "1.1.0", features = ["v4"]}
+jsonrpsee-core = "0.14.0"
 subxt = "0.22"
 mime = "0.3"
 mpart-async = "0.6.0"

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -104,7 +104,6 @@ mod tests {
             .await
             .context("unable to build pool or redis connection manager")
             .unwrap();
-        
 
         RedisCache::new(pool, PREFIX, Duration::from_secs(TTL))
     }

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -104,9 +104,9 @@ mod tests {
             .await
             .context("unable to build pool or redis connection manager")
             .unwrap();
-        let cache = RedisCache::new(pool, PREFIX, Duration::from_secs(TTL));
+        
 
-        cache
+        RedisCache::new(pool, PREFIX, Duration::from_secs(TTL))
     }
 
     #[tokio::test]

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -355,7 +355,6 @@ mod tests {
             .await
             .context("unable to build pool or redis connection manager")
             .unwrap();
-        
 
         RedisStorage::builder(pool)
             .prefix(PREFIX)

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -373,19 +373,15 @@ mod tests {
             id: String::from(id),
             command: String::from("test.get"),
             expiration: 300,
-            data: String::from(""),
-            tag: None,
             source: 1,
             destination: vec![4],
             reply: String::from("de31075e-9af4-4933-b107-c36887d0c0f0"),
             retry: 2,
-            schema: String::from(""),
             timestamp: SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap()
                 .as_secs(),
-            error: None,
-            signature: None,
+            ..Message::default()
         };
 
         conn.lpush(&queue, &msg).await?;

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -355,12 +355,12 @@ mod tests {
             .await
             .context("unable to build pool or redis connection manager")
             .unwrap();
-        let storage = RedisStorage::builder(pool)
+        
+
+        RedisStorage::builder(pool)
             .prefix(PREFIX)
             .max_commands(500)
-            .build();
-
-        storage
+            .build()
     }
 
     async fn push_msg_to_local(id: &str, storage: &RedisStorage) -> Result<()> {

--- a/src/twin/substrate.rs
+++ b/src/twin/substrate.rs
@@ -99,7 +99,7 @@ impl ReconnectingClient {
         // here we inspect the request error
         // if it needs a restart, we just retry to get a new client
         let err = result.err().unwrap();
-        return match err {
+        match err {
             GenericError::Rpc(err) => match err {
                 RequestError::RestartNeeded(_) => {
                     log::debug!("restart needed, building a new client...");
@@ -114,7 +114,7 @@ impl ReconnectingClient {
                 _ => Err(err.into()),
             },
             _ => Err(err.into()),
-        };
+        }
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -50,6 +50,10 @@ pub struct Message {
     pub error: Option<String>,
     #[serde(rename = "sig")]
     pub signature: Option<String>,
+    #[serde(default)]
+    #[serde(skip_serializing)]
+    #[serde(rename = "pxy")]
+    pub proxy: bool,
 }
 
 pub trait Challengeable {
@@ -134,6 +138,7 @@ impl Default for Message {
             timestamp: Default::default(),
             error: None,
             signature: Default::default(),
+            proxy: Default::default(),
         }
     }
 }
@@ -151,10 +156,10 @@ impl Challengeable for Message {
         }
         write!(hash, "{}", self.reply)?;
         write!(hash, "{}", self.timestamp)?;
+
         // this is for backward compatibility
-        // this replaces the `proxy` flag which is
-        // no obsolete
-        write!(hash, "false")?;
+        // proxy flag is now obsolete
+        write!(hash, "{}", self.proxy)?;
 
         Ok(hash.compute())
     }

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -190,8 +190,7 @@ async fn handle_cmd(cmd: &str, redis_port: usize) -> Result<()> {
             serde_json::from_str(&result.unwrap().1).context("unable to parse response")?;
 
         (response.destination, response.source) = (vec![response.source], response.destination[0]);
-        conn
-            .lpush(&response.reply, &response)
+        conn.lpush(&response.reply, &response)
             .await
             .context("unable to push response")?;
     }


### PR DESCRIPTION
also keep the original message proxy flag to allow older clients (or current clients) to work without any changes.