### PR TITLE
There must be different response types

### DIFF
--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -15,7 +15,9 @@ pub mod storage;
 pub use e2e::Pair;
 
 use con::{Connection, Writer};
-use storage::{JsonIncomingRequest, JsonOutgoingRequest, JsonResponse};
+use storage::{
+    JsonIncomingRequest, JsonIncomingResponse, JsonOutgoingRequest, JsonOutgoingResponse,
+};
 
 use self::storage::JsonError;
 
@@ -219,7 +221,7 @@ where
     }
 
     // handle outgoing responses
-    async fn response(&self, response: JsonResponse) -> Result<()> {
+    async fn response(&self, response: JsonOutgoingResponse) -> Result<()> {
         // that's a reply message that is initiated locally and need to be
         // sent to a remote peer
         let mut envelope: Envelope = response
@@ -272,11 +274,11 @@ where
             self.storage
                 .reply(
                     reply_to,
-                    JsonResponse {
+                    JsonIncomingResponse {
                         version: 1,
                         reference: reference.clone(),
                         data: String::default(),
-                        destination: String::default(),
+                        source: String::default(),
                         schema: None,
                         timestamp: 0,
                         error: Some(err.into()),
@@ -421,7 +423,7 @@ where
             }
         };
 
-        let mut response: JsonResponse = envelope.try_into()?;
+        let mut response: JsonIncomingResponse = envelope.try_into()?;
         // set the reference back to original value
         response.reference = backlog.reference;
         log::trace!("pushing response to reply queue: {}", backlog.reply_to);

--- a/src/peer/storage/redis_storage.rs
+++ b/src/peer/storage/redis_storage.rs
@@ -2,7 +2,10 @@ use std::fmt::Display;
 
 use crate::types::Backlog;
 
-use super::{JsonIncomingRequest, JsonMessage, JsonOutgoingRequest, JsonResponse, Storage};
+use super::{
+    JsonIncomingRequest, JsonIncomingResponse, JsonMessage, JsonOutgoingRequest,
+    JsonOutgoingResponse, Storage,
+};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use bb8_redis::{
@@ -167,7 +170,7 @@ impl Storage for RedisStorage {
         Ok(())
     }
 
-    async fn reply(&self, queue: &str, response: JsonResponse) -> Result<()> {
+    async fn reply(&self, queue: &str, response: JsonIncomingResponse) -> Result<()> {
         let mut conn = self.get_connection().await?;
         // set reply queue
 
@@ -192,7 +195,7 @@ impl Storage for RedisStorage {
         } else {
             // reply queue had the message itself
             // decode it directly
-            JsonResponse::from_redis_value(&value)
+            JsonOutgoingResponse::from_redis_value(&value)
                 .context("failed to load json response")?
                 .into()
         };


### PR DESCRIPTION
The reason is, an outgoing response sent by the server have ONLY destination twin, where to send the reply to.

A client, who is receiving the response should see the source twin instead. so it can tell which twin responded to its request