### PR TITLE
Add Dockerfile and workflow for ARM

### DIFF
--- a/.github/workflows/release_arm.yaml
+++ b/.github/workflows/release_arm.yaml
@@ -1,0 +1,50 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Release ARM Container
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME_PEER: ${{ github.repository_owner }}/rmb-peer
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PEER }}
+          flavor: |
+            suffix=-arm,onlatest=true
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: .
+          platforms: linux/arm64
+          file: build/arm/peer/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/build/arm/peer/Dockerfile
+++ b/build/arm/peer/Dockerfile
@@ -1,0 +1,18 @@
+FROM --platform=amd64 ghcr.io/cross-rs/aarch64-unknown-linux-musl:latest AS build
+
+RUN apt update && apt install -y git curl unzip musl-dev musl-tools
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh && sh rustup.sh -y
+RUN . /root/.cargo/env && rustup target add aarch64-unknown-linux-musl
+
+WORKDIR /
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip
+RUN unzip -d /usr/local protoc-21.12-linux-x86_64.zip
+
+ARG VERSION
+WORKDIR /rmb-rs
+COPY . .
+RUN . /root/.cargo/env && cargo build --release --target aarch64-unknown-linux-musl
+RUN aarch64-linux-musl-strip /rmb-rs/target/aarch64-unknown-linux-musl/release/rmb-peer
+
+FROM --platform=arm64 alpine
+COPY --from=build /rmb-rs/target/aarch64-unknown-linux-musl/release/rmb-peer /usr/sbin

--- a/build/arm/peer/Dockerfile
+++ b/build/arm/peer/Dockerfile
@@ -1,6 +1,7 @@
 FROM --platform=amd64 ghcr.io/cross-rs/aarch64-unknown-linux-musl:latest AS build
 
 RUN apt update && apt install -y git curl unzip musl-dev musl-tools
+
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh && sh rustup.sh -y
 RUN . /root/.cargo/env && rustup target add aarch64-unknown-linux-musl
 
@@ -8,7 +9,6 @@ WORKDIR /
 RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip
 RUN unzip -d /usr/local protoc-21.12-linux-x86_64.zip
 
-ARG VERSION
 WORKDIR /rmb-rs
 COPY . .
 RUN . /root/.cargo/env && cargo build --release --target aarch64-unknown-linux-musl
@@ -16,3 +16,4 @@ RUN aarch64-linux-musl-strip /rmb-rs/target/aarch64-unknown-linux-musl/release/r
 
 FROM --platform=arm64 alpine
 COPY --from=build /rmb-rs/target/aarch64-unknown-linux-musl/release/rmb-peer /usr/sbin
+ENTRYPOINT [ "/usr/sbin/rmb-peer" ]


### PR DESCRIPTION
Adds a Dockerfile and Github workflow to build and release an `rmb-peer` container for the arm64 architecture. See https://github.com/threefoldtech/farmerbot/issues/11 for motivation and discussion.

Notes on the builds:

* Cross compiling is done using the base image provided by [cross-rs](https://github.com/cross-rs/cross). It's function is to provide a C toolchain targeting `aarch64-unknown-linux-musl`. Such a toolchain is not readily available from official sources like the Ubuntu package repos, and this appears to be a reliable source (1M+ downloads across their various builds)
* Some other options, like targeting `gnu` vs `musl` or building on a native toolchain within an emulated Alpine container, do exist. I ruled them out for the sake of consistency with the mainline builds and extremely long build times in that latter case

General notes:

* All changes are adjacent to the existing workflows, to prevent any issues or complications with the mainline builds
* The container images are tagged with a suffix `-arm`, for example `latest-arm` or `v1.0.6-arm`. While different architecture can coexist under a single tag, it's only possible if all are built under a single workflow run (avoided to preserve the point above)
* Any suggestions regarding how to organize the new files, in terms of directory structure or naming conventions, are welcome