### PR TITLE
Update rmb-tester helper scripts

### DIFF
--- a/tools/rmb_tester/.gitignore
+++ b/tools/rmb_tester/.gitignore
@@ -1,0 +1,7 @@
+
+/venv/
+
+rmb-peer.log
+
+dump.rdb
+

--- a/tools/rmb_tester/README.md
+++ b/tools/rmb_tester/README.md
@@ -64,7 +64,26 @@ python3 ./msg_handler.py -h
 ```
 
 ## Recipes:
-- Test all online nodes (based on up reports) to ensure that they are reachable over RMB
+### Simple method for testing live nodes:
+- For simplicity, you can install this tool's dependencies by running the ``install.sh` script:
+```sh
+./install
+```
+
+you can start testing live nodes if it is reachable over rmb by running `test-live-nodes.sh` script. it takes only one argument, the network name (one of `dev`, `qa`, `test`, `main`) and required to pass set you mnemonic as env var `MNEMONIC`. for testing dev network nodes:
+```sh
+MNEMONIC="[YOUR MNEMONIC]" ./test_live_nodes.sh dev
+```
+optionally, set `TIMEOUT` and/or `RMB_BIN`.
+`TIMEOUT` : set message ttl and client timeout. default to 60 (for large number of destinations use appropriate value)
+`RMB_BIN` : set the path of the rmb_peer binary file. default to `../../target/x86_64-unknown-linux-musl/release/rmb-peer`
+
+```sh
+MNEMONIC="[YOUR MNEMONIC]" TIMEOUT=500 ./test_live_nodes.sh main
+```
+
+### More Customized method:
+- Test all dest twins to ensure that they are reachable over RMB
 ```sh
 # The nodes.sh script when used with `--likely-up` option will output the IDs of the online nodes in the network using the gridproxy API.
 python3 ./rmb_tester.py -d $(./scripts/twins.sh --likely-up main) -c "rmb.version" -t 600 -e 600

--- a/tools/rmb_tester/install.sh
+++ b/tools/rmb_tester/install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+echo ">> creating and activating the virtual environment .."
+python3 -m venv venv
+source venv/bin/activate
+echo ">> installing .."
+python3 -m pip install --upgrade pip
+pip install -r ./requirements.txt
+echo "deactivating the virtual environment .."
+deactivate
+echo ">> install complete!"
+echo ">> to activate the virtual environment use 'source venv/bin/activate'"
+echo ">> or use ./test-live-nodes.sh script"
+echo ">> example: MNEMONIC=[MNEMONIC] ./test-live-nodes.sh [dev,qa,test,main]"
+echo ">> example: MNEMONIC=[MNEMONIC] TIMEOUT=[SECONDS] RMB_BIN=[BINARY-PATH] ./test-live-nodes.sh [dev,qa,test,main]"

--- a/tools/rmb_tester/requirements.txt
+++ b/tools/rmb_tester/requirements.txt
@@ -1,3 +1,3 @@
 alive-progress==2.4.1
-redis==4.3.1
+redis==5.0.1
 hiredis==2.0.0

--- a/tools/rmb_tester/scripts/twinid_to_nodeid.sh
+++ b/tools/rmb_tester/scripts/twinid_to_nodeid.sh
@@ -18,7 +18,7 @@ esac
 if [[ "$1" == "main" ]]; then
   gridproxy_url="https://gridproxy.grid.tf"
 else
-  gridproxy_url="https://gridproxy.$2.grid.tf"
+  gridproxy_url="https://gridproxy.$1.grid.tf"
 fi
 
 

--- a/tools/rmb_tester/test_live_nodes.sh
+++ b/tools/rmb_tester/test_live_nodes.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+case $1 in
+    main|dev|qa|test )  # Ok
+        ;;
+    *)
+        # The wrong first argument.
+        echo 'Expected "dev", "qa", "test", or "main" as second arg' >&2
+        exit 1
+esac
+
+
+if [[ "$1" == "main" ]]; then
+  SUBSTRATE_URL="wss://tfchain.grid.tf:443"
+  RELAY_URL="wss://relay.grid.tf"
+else
+  SUBSTRATE_URL="wss://tfchain.$1.grid.tf:443"
+  RELAY_URL="wss://relay.$1.grid.tf"
+fi
+RMB_LOG_FILE="./rmb-peer.log"
+TIMEOUT="${TIMEOUT:-60}"
+RMB_BIN="${RMB_BIN:-../../target/x86_64-unknown-linux-musl/release/rmb-peer}"
+
+cleanup() {
+    echo "stop all bash managed jobs"
+    jlist=$(jobs -p)
+    plist=$(ps --ppid $$ | awk '/[0-9]/{print $1}')
+    
+    kill ${jlist:-$plist}
+}
+
+trap cleanup SIGHUP	SIGINT SIGQUIT SIGABRT SIGTERM
+
+
+# start redis in backgroud and skip errors in case alreday running
+set +e
+echo "redis-server starting .."
+
+redis-server --port 6379 2>&1 > /dev/null&
+sleep 3
+set -e
+
+# start rmb in background
+echo "rmb-peer starting .."
+$RMB_BIN -m "$MNEMONIC" --substrate "$SUBSTRATE_URL" --relay "$RELAY_URL" --redis "redis://localhost:6379" --debug &> $RMB_LOG_FILE &
+
+# wait till peer establish connection to a relay
+timeout --preserve-status 10 tail -f -n0 $RMB_LOG_FILE | grep -qe 'now connected' || (echo "rmb-peer taking too much time to start! check the log at $RMB_LOG_FILE for more info." && cleanup)
+
+# start rmb_tester
+source venv/bin/activate
+echo "rmb_tester starting .."
+python3 ./rmb_tester.py -d $(./scripts/twins.sh --likely-up $1) -c "rmb.version" -t $TIMEOUT -e $TIMEOUT --short
+deactivate
+
+cleanup


### PR DESCRIPTION
Changes:
- Adding `install.sh` and `test-live-nodes.sh` scripts
- Updating `redis-py`  version in `requirement.txt`
- Fix typo in `twinid_to_nodeid.sh`
- Update README.md
- Add some files to .gitignore

- `install.sh`: will create virtual env and install all dependencies 
- `test-live-nodes.sh`: this script will do the following: 
  1. start `redis-server`, ignore errors if it is already running.
  2. start `rmb-peer` using specific network, wait till it ready, and forward logs to `rmb-peer.log`
  3. retrieve all nodes' twins ids in specific network filtered by `up` node status by querying grid-proxy. 
  4. activate python virtual environment and start `rmb-tester`.
  5. test all live nodes from specific network that supposed to be up and provide a detailed report.
  6. clean up all running processes and exit.

![Screenshot from 2023-12-25 14-52-00](https://github.com/threefoldtech/rmb-rs/assets/42457449/4cf6f20d-4497-41f4-9ae3-b8ecfa6108d1)
