### PR TITLE
implement in-mem cache with ttl for peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,6 +2658,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linregress"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3870,6 +3876,7 @@ dependencies = [
  "tokio-retry",
  "tokio-stream",
  "tokio-tungstenite",
+ "ttl_cache",
  "url",
  "uuid",
  "workers",
@@ -5948,6 +5955,15 @@ name = "tt-call"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
+
+[[package]]
+name = "ttl_cache"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4189890526f0168710b6ee65ceaedf1460c48a14318ceec933cb26baa492096a"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ jwt = "0.16"
 subxt = { version = "0.28.0", features = ["substrate-compat"]}
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 itertools = "0.11"
+ttl_cache = "0.5"
 
 # for static build
 openssl = { version = "0.10", features = ["vendored"] }

--- a/src/bins/rmb-peer.rs
+++ b/src/bins/rmb-peer.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use clap::{builder::ArgAction, Args, Parser};
-use rmb::cache::RedisCache;
+use rmb::cache::MemCache;
 use rmb::identity::KeyType;
 use rmb::identity::{Identity, Signer};
 use rmb::peer::Pair;
@@ -149,11 +149,10 @@ async fn app(args: Params) -> Result<()> {
         .context("failed to initialize redis pool")?;
 
     // cache is a little bit tricky because while it improves performance it
-    // makes changes to twin data takes at least 5 min before they are detected
-    let db =
-        SubstrateTwinDB::<RedisCache>::new(args.substrate, RedisCache::new(pool.clone(), "twin"))
-            .await
-            .context("cannot create substrate twin db object")?;
+    // makes changes to twin data takes at least 2 min before they are detected
+    let db = SubstrateTwinDB::new(args.substrate, MemCache::default())
+        .await
+        .context("cannot create substrate twin db object")?;
 
     let id = db
         .get_twin_with_account(signer.account())

--- a/src/peer/storage/mod.rs
+++ b/src/peer/storage/mod.rs
@@ -137,7 +137,7 @@ impl JsonOutgoingRequest {
         backlog.reference = self.reference;
 
         let mut env = Envelope::new();
-        env.uid = backlog.uid.clone();
+        env.uid.clone_from(&backlog.uid);
         env.set_plain(base64::decode(self.data).context("invalid data base64 encoding")?);
         env.tags = self.tags;
         env.timestamp = self.timestamp;

--- a/src/relay/federation/mod.rs
+++ b/src/relay/federation/mod.rs
@@ -179,7 +179,7 @@ mod test {
         let reg = prometheus::Registry::new();
         let pool = redis::pool("redis://localhost:6379", 10).await.unwrap();
         let sink = Sink::new(pool.clone());
-        let mem: MemCache<Twin> = MemCache::new();
+        let mem: MemCache<Twin> = MemCache::default();
         let account_id: AccountId32 = "5EyHmbLydxX7hXTX7gQqftCJr2e57Z3VNtgd6uxJzZsAjcPb"
             .parse()
             .unwrap();

--- a/src/relay/federation/router.rs
+++ b/src/relay/federation/router.rs
@@ -150,7 +150,7 @@ mod test {
 
         // Start a lightweight mock server.
         let server = MockServer::start();
-        let mem: MemCache<Twin> = MemCache::new();
+        let mem: MemCache<Twin> = MemCache::default();
         let account_id: AccountId32 = "5EyHmbLydxX7hXTX7gQqftCJr2e57Z3VNtgd6uxJzZsAjcPb"
             .parse()
             .unwrap();

--- a/src/relay/switch/session.rs
+++ b/src/relay/switch/session.rs
@@ -68,7 +68,7 @@ impl From<&StreamID> for Address {
     fn from(value: &StreamID) -> Self {
         let mut address = Address::new();
         address.twin = value.0;
-        address.connection = value.1.clone();
+        address.connection.clone_from(&value.1);
 
         address
     }

--- a/src/twin/substrate.rs
+++ b/src/twin/substrate.rs
@@ -259,37 +259,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_ashraf_twin() {
-        let db = SubstrateTwinDB::new(vec![String::from("wss://tfchain.grid.tf:443")], NoCache)
-            .await
-            .context("cannot create substrate twin db object")
-            .unwrap();
-
-        let twin = db
-            .get_twin(4307)
-            .await
-            .context("can't get twin from substrate")
-            .unwrap()
-            .unwrap();
-
-        // NOTE: this currently checks against devnet substrate
-        // as provided by the url wss://tfchain.dev.grid.tf.
-        // if this environment was reset at some point. those
-        // values won't match anymore.
-
-        assert!(!matches!(twin.relay, None));
-        let relay = twin.relay.unwrap();
-        assert_eq!(relay.0.len(), 1);
-        assert!(relay.0.contains("relay.02.grid.tf"));
-        assert!(twin.pk.is_some());
-
-        assert_eq!(
-            twin.account.to_string(),
-            "5GYtsF9XyaWUEa1zZMhZRe1p9XRMkF21wGyg4G7pPrJok942"
-        );
-    }
-
-    #[tokio::test]
     async fn test_get_twin_id() {
         let db = SubstrateTwinDB::new(vec![String::from("wss://tfchain.dev.grid.tf:443")], NoCache)
             .await

--- a/src/twin/substrate.rs
+++ b/src/twin/substrate.rs
@@ -195,7 +195,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_twin_with_mem_cache() {
-        let mem: MemCache<Twin> = MemCache::new();
+        let mem: MemCache<Twin> = MemCache::default();
 
         let db = SubstrateTwinDB::new(
             vec![String::from("wss://tfchain.dev.grid.tf:443")],
@@ -255,6 +255,37 @@ mod tests {
         assert_eq!(
             twin.account.to_string(),
             "5Eh2stFNQX4khuKoh2a1jQBVE91Lv3kyJiVP2Y5webontjRe"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_ashraf_twin() {
+        let db = SubstrateTwinDB::new(vec![String::from("wss://tfchain.grid.tf:443")], NoCache)
+            .await
+            .context("cannot create substrate twin db object")
+            .unwrap();
+
+        let twin = db
+            .get_twin(4307)
+            .await
+            .context("can't get twin from substrate")
+            .unwrap()
+            .unwrap();
+
+        // NOTE: this currently checks against devnet substrate
+        // as provided by the url wss://tfchain.dev.grid.tf.
+        // if this environment was reset at some point. those
+        // values won't match anymore.
+
+        assert!(!matches!(twin.relay, None));
+        let relay = twin.relay.unwrap();
+        assert_eq!(relay.0.len(), 1);
+        assert!(relay.0.contains("relay.02.grid.tf"));
+        assert!(twin.pk.is_some());
+
+        assert_eq!(
+            twin.account.to_string(),
+            "5GYtsF9XyaWUEa1zZMhZRe1p9XRMkF21wGyg4G7pPrJok942"
         );
     }
 


### PR DESCRIPTION
- The rmb peer should use an inmemory cache instead of redis
- it also must have a ttl for twins
- also run clippy