### PR TITLE
fix rmb calls timeout

### DIFF
--- a/src/bins/rmb-relay.rs
+++ b/src/bins/rmb-relay.rs
@@ -173,7 +173,7 @@ async fn app(args: Args, tx: tokio::sync::oneshot::Sender<()>) -> Result<()> {
 
     let mut l = events::Listener::new(args.substrate, redis_cache).await?;
     tokio::spawn(async move {
-        let max_retries = 7;// max wait is 2^7 = 128 seconds ( 2 minutes)
+        let max_retries = 7; // max wait is 2^7 = 128 seconds ( 2 minutes)
         let mut attempt = 0;
         let mut backoff = Duration::from_secs(1);
 
@@ -225,5 +225,4 @@ async fn main() {
             std::process::exit(1);
         }
     }
-    
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -60,7 +60,7 @@ where
         anyhow::bail!("failed to connect to substrate using the provided urls")
     }
 
-    pub async fn listen(&mut self) -> Result<()> {
+    pub async fn listen(&mut self, got_hit: &mut bool) -> Result<()> {
         loop {
             // always flush in case some blocks were finalized before reconnecting
             if let Err(err) = self.cache.flush().await {
@@ -73,6 +73,8 @@ where
                 if let Some(subxt::Error::Rpc(_)) = err.downcast_ref::<subxt::Error>() {
                     self.api = Self::connect(&mut self.substrate_urls).await?;
                 }
+            } else {
+                *got_hit = true
             }
         }
     }


### PR DESCRIPTION
### Description

added exponential backoff and app exit when the listener thread is down

### Changes

`src/bins/rmb-relay.rs` file

### Related Issues

[issue#200](https://github.com/threefoldtech/rmb-rs/issues/200)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
