### PR TITLE
increase the wiggle factor for pool size and fed workers size

### DIFF
--- a/src/bins/rmb-relay.rs
+++ b/src/bins/rmb-relay.rs
@@ -124,7 +124,7 @@ async fn app(args: Args, tx: oneshot::Sender<()>) -> Result<()> {
     // of number of workers is needed
 
     // a wiggle is 10% of number of workers with min of 1
-    let wiggle = std::cmp::max((args.workers * 10) / 100, 1);
+    let wiggle = std::cmp::max((args.workers * 50) / 100, 5);
     let pool_size = args.workers + wiggle;
     let fed_size = wiggle * 2;
 

--- a/src/bins/rmb-relay.rs
+++ b/src/bins/rmb-relay.rs
@@ -123,7 +123,7 @@ async fn app(args: Args, tx: oneshot::Sender<()>) -> Result<()> {
     // push to the queue that depends on how fast messages are sent but we can assume an extra 10%
     // of number of workers is needed
 
-    // a wiggle is 10% of number of workers with min of 1
+    // a wiggle is 50% of the number of workers with a minimum of 5
     let wiggle = std::cmp::max((args.workers * 50) / 100, 5);
     let pool_size = args.workers + wiggle;
     let fed_size = wiggle * 2;


### PR DESCRIPTION
This PR increases the size of the redis pool and allows more federation workers to handle federation jobs.

For better context, this fixes the issue that a relay with 2 workers that is supposed to handle 2000 users per spec can't handle even 2 users due to insufficient idle connections in the Redis pool. It may be only due to the minimum size of 1, which is insufficient (we need a dedicated Redis connection for pulling the fed queue, then no idle connections would be left for other on-demand operations, for example, when a user sends a message we need to `XADD` it to the user streams)
