### PR TITLE
Fix: gracefully close websocket writer on cancellation to prevent half-closed sockets

### DIFF
--- a/src/relay/api.rs
+++ b/src/relay/api.rs
@@ -345,6 +345,11 @@ impl ConnectionWriter {
             }
         }
 
+        // Ensure the websocket writer is gracefully closed on cancellation to avoid half-closed sockets
+        if let Err(e) = self.writer.close().await {
+            log::debug!("writer close on cancel failed: {}", e);
+        }
+
         drop(drop_guard);
     }
 }


### PR DESCRIPTION
context: https://github.com/threefoldtech/rmb-rs/issues/233
