### PR TITLE
ci: add override flag to rust toolchain installation in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
         name: Install toolchain
         with:
           toolchain: stable
+          override: true
           target: x86_64-unknown-linux-musl
       - uses: actions-rs/cargo@v1
         name: Build release


### PR DESCRIPTION
This PR updates the CI workflow to include the `--override` flag when installing Rust targets with rustup.

Details

Previously, the workflow used rustup target add <target> without --override.

Added --override ensures the specified target is installed and available for the active toolchain in the workflow.
reference: https://github.com/actions-rs/toolchain?tab=readme-ov-file#inputs

This helps prevent build failures like:
```
error[E0463]: can't find crate for `core`
note: the `x86_64-unknown-linux-musl` target may not be installed
``` 
I tried the build on an example workflow on https://github.com/threefoldtech/rmb-rs/actions/runs/18095666645/job/51485995286
related issue:
 - #235 