### PR TITLE
Repoint tfchain git dependency -> ledger_chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5921,7 +5921,7 @@ dependencies = [
 [[package]]
 name = "tfchain-client"
 version = "0.2.0"
-source = "git+https://github.com/threefoldtech/tfchain.git?branch=development#0f66e0c303ffc7b102f5d3f975459f7020cb76a0"
+source = "git+https://github.com/threefoldtech/ledger_chain.git?branch=development#0f66e0c303ffc7b102f5d3f975459f7020cb76a0"
 dependencies = [
  "frame-metadata",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ hyper-tungstenite = "0.14"
 lazy_static = "1.4.0"
 prometheus = { version = "0.13", features = ["process"] }
 
-tfchain-client = { git = "https://github.com/threefoldtech/tfchain.git", version = "0.2.0", branch = "development" }
+tfchain-client = { git = "https://github.com/threefoldtech/ledger_chain.git", version = "0.2.0", branch = "development" }
 reqwest = "0.12"
 bytes = "1"
 


### PR DESCRIPTION
github.com/threefoldtech/tfchain was renamed to ledger_chain. Repoints the tfchain-client git dependency in Cargo.toml and Cargo.lock to github.com/threefoldtech/ledger_chain (same development branch + pinned commit exist there), removing the dependency on GitHub's non-permanent rename redirect. Part of #2693.